### PR TITLE
Add header with length to messages

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,7 @@ user_interface:
     host: thinkpad
     input_port: 12345
     output_port: 12346
+    header_length: 4
 
 fan:
     host: thinkpad

--- a/sctcamsoft/gui/main.py
+++ b/sctcamsoft/gui/main.py
@@ -46,6 +46,7 @@ class mywindow(QtWidgets.QWidget,Ui_Dialog):
         self._server_handler = ServerIO(ui_config['host'], 
                                         ui_config['input_port'], 
                                         ui_config['output_port'], 
+                                        ui_config['header_length'],
                                         commands)
         self._server_handler.start()
         self.send_command.connect(self._server_handler.send_command)
@@ -59,6 +60,7 @@ class mywindow(QtWidgets.QWidget,Ui_Dialog):
 
         # Tell the server to start sending updates
         self.send_command.emit('connect_devices')
+        self.send_command.emit('set_alerts')
         self.send_command.emit('set_monitoring')
         
         self.fan = FanControls(

--- a/sctcamsoft/gui/server_io.py
+++ b/sctcamsoft/gui/server_io.py
@@ -10,12 +10,13 @@ class ServerIO(QThread):
     on_update = pyqtSignal(object)
 
     def __init__(self, host, server_input_port, 
-                 server_output_port, commands):
+                 server_output_port, header_length, commands):
         QThread.__init__(self)
 
         self._host = host
         self._send_cmd_port = server_input_port
         self._recv_update_port = server_output_port
+        self._header_length = header_length
 
         self.attempt_connect_send()
         self.attempt_connect_recv()
@@ -33,14 +34,16 @@ class ServerIO(QThread):
     def run(self):
         while True:
             try:
-                serialized_message = self._recv_update_sock.recv(1024)
-                if serialized_message:
-                    user_update = sc.UserUpdate()
-                    user_update.ParseFromString(serialized_message)
-                    for update in user_update.updates:
-                        if (update.device == 'ALERT'):
-                            print("ALERT: {}".format(update.variable))
-                        self.on_update.emit(update)
+                header = self._recv_update_sock.recv(self._header_length)
+                if header:
+                    serialized_message = self._recv_update_sock.recv(int(header))
+                    if serialized_message:
+                        user_update = sc.UserUpdate()
+                        user_update.ParseFromString(serialized_message)
+                        for update in user_update.updates:
+                            if (update.device == 'ALERT'):
+                                print("ALERT: {}".format(update.variable))
+                            self.on_update.emit(update)
             except (socket.error, ConnectionError):
                 print('Connection to server lost.')
                 self.sleep(5)
@@ -72,10 +75,12 @@ class ServerIO(QThread):
         for user_arg, input_value in zip(user_args, user_input):
             message.args[user_arg] = input_value
             
-        serialized_command = message.SerializeToString()
+        serialized_message = message.SerializeToString()
+        header = "{{:0{}d}}".format(self._header_length).format(len(serialized_message))
+        full_message = header.encode() + serialized_message
 
         try:
-            self._send_cmd_sock.sendall(serialized_command)
+            self._send_cmd_sock.sendall(full_message)
         except (socket.error, ConnectionError):
             print('Error communicating with server.')
             self.sleep(5)

--- a/sctcamsoft/server.py
+++ b/sctcamsoft/server.py
@@ -25,6 +25,8 @@ class UserHandler():
         self.host = config['host']
         self.input_port = config['input_port']
         self.output_port = config['output_port']
+        self.header_length = config['header_length']
+        self.header_template = "{{:0{}d}}".format(self.header_length)
         self.selector = selectors.DefaultSelector()
         self.user_command = None
 
@@ -50,8 +52,11 @@ class UserHandler():
         self.selector.register(conn, selectors.EVENT_WRITE, self._write)
 
     def _read(self, conn, mask):
-        serialized_message = conn.recv(1024)
-        if serialized_message:
+        # Get length of the message from the header
+        header = conn.recv(self.header_length)
+        if header:
+            serialized_message = conn.recv(int(header))
+        if header and serialized_message:
             user_command = sc.UserCommand()
             user_command.ParseFromString(serialized_message)
             self.user_command = UserCommand(user_command.command,
@@ -68,7 +73,8 @@ class UserHandler():
                 update.device, update.variable, update.value = update_tuple
             self.user_update = None
             message = user_update.SerializeToString() 
-            conn.sendall(message)
+            header = self.header_template.format(len(message)).encode()
+            conn.sendall(header + message)
 
     def communicate_user(self, update):
         self.user_command = None

--- a/sctcamsoft/user_input.py
+++ b/sctcamsoft/user_input.py
@@ -21,6 +21,7 @@ with open(args.config_file, 'r') as config_file:
     config = yaml.load(config_file)
 server_host = config['user_interface']['host']
 server_port = config['user_interface']['input_port']
+header_length = config['user_interface']['header_length']
 
 # Open a socket to the slow control server
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -51,7 +52,9 @@ def parse_and_serialize_user_input(raw_user_input):
     message.command = command
     for user_arg, input_value in zip(user_args, user_input):
         message.args[user_arg] = input_value
-    return message.SerializeToString()
+    serialized_message = message.SerializeToString()
+    header = "{{:0{}d}}".format(header_length).format(len(serialized_message))
+    return header.encode() + serialized_message
 
 # Start a terminal for user input
 print("SCT Slow Control - Input")


### PR DESCRIPTION
Fixes bug in which multiple user command messages would be concatenated if sent sufficiently fast together, and only the first one would be parsed by the server. Now, a header provides the message length, allowing the server to read exactly one message at a time, preventing messages from being dropped.

I've only modified the command-line user input and user output codes. @jakedp7 @lunarphase would one of you be able to update the GUI code with the same fix before we merge this?

Fixes #2.